### PR TITLE
Use a separate fd just for status reporting

### DIFF
--- a/check-git-signature
+++ b/check-git-signature
@@ -72,11 +72,13 @@ def verify_sig(data_path, signature_path, keyring_path,
     downloaded
     :return: keyid if correct signature is found, None otherwise
     '''
+    pipe_r, pipe_w = os.pipe()
     gpg = subprocess.Popen(['gpgv2', '--keyring', keyring_path, '--status-fd',
-        '1', signature_path, data_path], stderr=open(os.devnull, 'w'),
-        stdout=subprocess.PIPE)
-    (output, _) = gpg.communicate()
-    for line in output.splitlines():
+        str(pipe_w), signature_path, data_path], stderr=open(os.devnull, 'w'),
+        stdout=open(os.devnull, 'w'))
+    os.close(pipe_w)
+    for line in os.fdopen(pipe_r):
+        line = line.rstrip()
         logger.debug('GPG status line: {}'.format(line))
         if line.startswith('[GNUPG:] GOODSIG '):
             # it's ok, get key ID


### PR DESCRIPTION
As noted in https://github.com/marmarek/signature-checker/commit/b962a326cd7c892f4833c92ecf01a5bb9ec169f9#commitcomment-20210054

If there is a way for attacker-controlled inputs to be quoted in output messages in some way with newlines not sanitized (not impossible to imagine), then using stdin or stdout for status messages may allow an attacker to confuse the status parser into thinking an invalid signature is actually valid.

Apparently I'm not the first to point this out: https://bugs.python.org/issue18544

However, the clean solution (`pass_fds`, a no-CLOEXEC whitelist) only exists in python3's subprocess module :(

A decent fallback IMO is having gpgv2 inherit an os.pipe (keeping `close_fds=False`) and using that as the `--status-fd`.