### PR TITLE
Ensure verify_tag_sig always returns a tuple

### DIFF
--- a/check-git-signature
+++ b/check-git-signature
@@ -166,8 +166,8 @@ def verify_tag_sig(tag_obj, keyring_path, download_missing_keys=False):
         data_path = os.path.join(tmpdir, 'tag')
         with open(data_path, 'w') as data_file:
             data_file.write(tag)
-        return verify_sig(data_path, signature_path, keyring_path,
-            download_missing_keys)
+        return (verify_sig(data_path, signature_path, keyring_path,
+            download_missing_keys), True)
     finally:
         shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
Currently verify_repository_ref incorrectly assumes it does.

```
Traceback (most recent call last):
  File "./check-git-signature", line 389, in <module>
    sys.exit(main())
  File "./check-git-signature", line 368, in main
    keyring, args.keyring is None)
  File "./check-git-signature", line 257, in verify_repository_ref
    if verify_result[0]:
TypeError: 'NoneType' object has no attribute '__getitem__'
```

(Line numbers are off by a bit due to having https://github.com/marmarek/signature-checker/pull/3 applied)