### PR TITLE
Stop checking defunct sks-keyservers pool

### DIFF
--- a/add-key
+++ b/add-key
@@ -8,7 +8,7 @@ keyid="$1"
 
 keyserver="$2"
 
-[ -n "$keyserver" ] || keyserver=hkp://pool.sks-keyservers.net
+[ -n "$keyserver" ] || keyserver=hkps://keyserver.ubuntu.com
 
 export GNUPGHOME=$(mktemp -d)
 trap "rm -rf $GNUPGHOME" EXIT

--- a/check-git-signature
+++ b/check-git-signature
@@ -131,7 +131,6 @@ def verify_sig(data_path, signature_path, keyring_path,
                 keyid, download_missing_keys))
             if download_missing_keys:
                 sources = ['hkps://keyserver.ubuntu.com',
-                           'hkp://pool.sks-keyservers.net',
                            'hkps://keys.openpgp.org']
                 for user in github_user:
                     github_url = 'https://github.com/{}.gpg'.format(user)


### PR DESCRIPTION
The signature checker currently checks a few keyservers. The `pool.sks-keyservers.net` service is now defunct.

There's the [archived announcement](https://web.archive.org/web/20220119094712/https://www.sks-keyservers.net/) on the old website.

>This service is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. Service reliability should not be expected.
>
>Update 2021-06-21: Due to even more GDPR takedown requests, the DNS records for the pool will no longer be provided at all.

It's gone from DNS.

```
$ dig pool.sks-keyservers.net

; <<>> DiG 9.18.20 <<>> pool.sks-keyservers.net
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 23627
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;pool.sks-keyservers.net.	IN	A

;; Query time: 2468 msec
;; SERVER: 10.139.1.1#53(10.139.1.1) (UDP)
;; WHEN: Tue Dec 26 20:14:47 MST 2023
;; MSG SIZE  rcvd: 52
```

This patch removes the defunct service from being checked. That leaves 2 active keyservers (plus the GitHub account check):

* `keyserver.ubuntu.com`
* `keys.openpgp.org`

The `add-key` script was defaulting to the defunct service. This changes the default to the first on the list, `keyserver.ubuntu.com`.

My key used to sign the commit is on both servers.